### PR TITLE
New-style classes and Cartridge + metaclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/gb/cartridge.py
+++ b/gb/cartridge.py
@@ -106,7 +106,7 @@ class Mbc1Cartridge(Cartridge):
       return self.rombanks[
         self.rom_select + (1-self.mode_select)*(self.bankset_select << 5)][addr-0x4000]
     elif self.ram_enable == 0xA:
-        return self.rambanks[self.mode_select * self.bankset_select][addr-0x8000]
+      return self.rambanks[self.mode_select * self.bankset_select][addr-0x8000]
 
   def __setitem__(self, addr, value):
     if addr < 0x0 or addr > 0x9FFF:

--- a/gb/cartridge.py
+++ b/gb/cartridge.py
@@ -50,13 +50,15 @@ class Cartridge(object):
       if not romstring:
         cls = DummyCartridge
       else:
+        # 2/3: convert to bytearry to ensure uniform indexing. Could also use
+        # six.indexbytes, but that doesn't work on existing bytearrays, so we would still
+        # need a conversion, and we might as well use python builtins if we can.
+        romstring = bytearray(romstring)
         if len(romstring) < ROM_TYPE_BYTE:
           raise ValueError(
             "Unable to read cartridge type: cartridge type located at byte %d, but "
             "romstring was only %d bytes long." % (ROM_TYPE_BYTE, len(romstring)))
-        # 2/3 evil index function which we have to use because Python 2 is evil and has
-        # "bytes" as an alias of "str" and indexing a "str" returns a 1 character "str".
-        cart_type = six.indexbytes(romstring, ROM_TYPE_BYTE)
+        cart_type = romstring[ROM_TYPE_BYTE]
 
         if cart_type in Cartridge._cartridge_registry:
           cls = Cartridge._cartridge_registry[cart_type]

--- a/gb/cartridge.py
+++ b/gb/cartridge.py
@@ -35,6 +35,11 @@ class CartridgeMeta(type):
 
 @six.add_metaclass(CartridgeMeta)
 class Cartridge(object):
+  """Base class for Cartridges. Calling the Cartridge constructor with a romstring
+  automatically constructs the appropriate child class, if a child class exists which has
+  the cartridge type id in its "ids" variable.
+
+  """
 
   def __new__(cls, romstring=b''):
     """Instantiate the appropriate cartridge subtype automatically, given the romstring. If

--- a/gb/cartridge.py
+++ b/gb/cartridge.py
@@ -1,6 +1,68 @@
+import six
+from six.moves import xrange
+
 from gb.mem import *
 
-class DummyCartridge(object):
+ROM_TYPE_BYTES = 0x147
+
+class CartridgeError(Exception):
+  """Base exception for this module."""
+  pass
+
+class RegistrationError(CartridgeError):
+  """Error raised when a cartridge tries to register itself with an illegal state."""
+  pass
+
+class CartridgeMeta(type):
+  """Metaclass for cartridges, causing automatic registration of subclasses."""
+
+  def __init__(cls, name, bases, dct):
+    """Add a registry to base classes, and register any class that provides "ids"."""
+    if not hasattr(cls, '_cartridge_registry'):
+      # Add a registry to the class if it doesn't have one. This would imply that it's a
+      # base class.
+      cls._cartridge_registry = {}
+    if hasattr(cls, 'ids'):
+      # iterate over the ids presented by the class and register it to each id given.
+      for i in cls.ids:
+        if i in cls._cartridge_registry:
+          raise RegistrationError(
+            "Cartridge class %s registers id %x which is already registered by %s" %
+            (cls, i, cls._cartridge_registry[i]))
+        cls._cartridge_registry[i] = cls
+
+    super(CartridgeMeta, cls).__init__(name, bases, dct)
+
+@six.add_metaclass(CartridgeMeta)
+class Cartridge(object):
+
+  def __new__(cls, romstring=b''):
+    """Instantiate the appropriate cartridge subtype automatically, given the romstring. If
+    the romstring is empty, instantiate a DummyCartridge.
+
+    """
+    if cls is Cartridge:
+      if not romstring:
+        cls = DummyCartridge
+      else:
+        if len(romstring) < ROM_TYPE_BYTES:
+          raise ValueError(
+            "Unable to read cartridge type: cartridge type located at byte %d, but "
+            "romstring was only %d bytes long." % (ROM_TYPE_BYTES, len(romstring)))
+        # 2/3 evil index function which we have to use because Python 2 is evil and has
+        # "bytes" as an alias of "str" and indexing a "str" returns a 1 character "str".
+        cart_type = six.indexbytes(romstring, ROM_TYPE_BYTES)
+
+        if cart_type in Cartridge._cartridge_registry:
+          cls = Cartridge._cartridge_registry[cart_type]
+        else:
+          raise ValueError("Unsupported Cartridge type.")
+    else:
+      raise ValueError("You have subclassed Cartridge incorrectly, somehow.")
+
+    return super(Cartridge, cls).__new__(cls)
+
+class DummyCartridge(Cartridge):
 
   def __init__(self):
     pass
@@ -12,9 +74,9 @@ class DummyCartridge(object):
     pass
 
 
-class Mbc1Cartridge(object):
+class Mbc1Cartridge(Cartridge):
 
-  ids = set(['\x01','\x02','\x03'])
+  ids = [0x1, 0x2, 0x3]
 
   def __init__(self, romstring):
     self.ram_enable = 0
@@ -36,7 +98,8 @@ class Mbc1Cartridge(object):
     if addr < 0x4000:
       return self.rombanks[0][addr]
     elif addr < 0x8000:
-      return self.rombanks[self.rom_select + (1-self.mode_select)*(self.bankset_select << 5)][addr-0x4000]
+      return self.rombanks[
+        self.rom_select + (1-self.mode_select)*(self.bankset_select << 5)][addr-0x4000]
     elif self.ram_enable == 0xA:
         return self.rambanks[self.mode_select * self.bankset_select][addr-0x8000]
 
@@ -57,11 +120,8 @@ class Mbc1Cartridge(object):
 
 def load_rom_from_file(path):
   with open(path, "rb") as f:
+    # 2/3: Python 2's "bytes" type is useless, so we have to use a bytearray to get the
+    # behavior we want.
     romstring = f.read()
 
-  cart_type = romstring[0x147]
-
-  if cart_type in Mbc1Cartridge.ids:
-    return Mbc1Cartridge(romstring)
-  else:
-    raise ValueError("Cartridge of unsupported type.")
+  return Cartridge(romstring)

--- a/gb/cartridge.py
+++ b/gb/cartridge.py
@@ -1,6 +1,6 @@
 from gb.mem import *
 
-class DummyCartridge:
+class DummyCartridge(object):
 
   def __init__(self):
     pass
@@ -12,7 +12,7 @@ class DummyCartridge:
     pass
 
 
-class MBC1Cartridge:
+class Mbc1Cartridge(object):
 
   ids = set(['\x01','\x02','\x03'])
 
@@ -22,12 +22,12 @@ class MBC1Cartridge:
     self.bankset_select = 0
     self.mode_select = 0
 
-    self.rombanks = [ROM(romstring[x:x+0x4000]) for x in xrange(0, len(romstring), 0x4000)]
+    self.rombanks = [Rom(romstring[x:x+0x4000]) for x in xrange(0, len(romstring), 0x4000)]
     self.rombanks.insert(32, self.rombanks[0])
     self.rombanks.insert(64, self.rombanks[0])
     self.rombanks.insert(96, self.rombanks[0])
     if len(self.rombanks) < 128:
-      self.rombanks = self.rombanks + [ROM(0x4000)] * (128 - len(self.rombanks))
+      self.rombanks = self.rombanks + [Rom(0x4000)] * (128 - len(self.rombanks))
     self.rambanks = 4 * [bytearray(8192)]
 
   def __getitem__(self, addr):
@@ -61,7 +61,7 @@ def load_rom_from_file(path):
 
   cart_type = romstring[0x147]
 
-  if cart_type in MBC1Cartridge.ids:
-    return MBC1Cartridge(romstring)
+  if cart_type in Mbc1Cartridge.ids:
+    return Mbc1Cartridge(romstring)
   else:
     raise ValueError("Cartridge of unsupported type.")

--- a/gb/cartridge.py
+++ b/gb/cartridge.py
@@ -3,7 +3,7 @@ from six.moves import xrange
 
 from gb.mem import *
 
-ROM_TYPE_BYTES = 0x147
+ROM_TYPE_BYTE = 0x147
 
 class CartridgeError(Exception):
   """Base exception for this module."""
@@ -45,13 +45,13 @@ class Cartridge(object):
       if not romstring:
         cls = DummyCartridge
       else:
-        if len(romstring) < ROM_TYPE_BYTES:
+        if len(romstring) < ROM_TYPE_BYTE:
           raise ValueError(
             "Unable to read cartridge type: cartridge type located at byte %d, but "
-            "romstring was only %d bytes long." % (ROM_TYPE_BYTES, len(romstring)))
+            "romstring was only %d bytes long." % (ROM_TYPE_BYTE, len(romstring)))
         # 2/3 evil index function which we have to use because Python 2 is evil and has
         # "bytes" as an alias of "str" and indexing a "str" returns a 1 character "str".
-        cart_type = six.indexbytes(romstring, ROM_TYPE_BYTES)
+        cart_type = six.indexbytes(romstring, ROM_TYPE_BYTE)
 
         if cart_type in Cartridge._cartridge_registry:
           cls = Cartridge._cartridge_registry[cart_type]
@@ -120,8 +120,6 @@ class Mbc1Cartridge(Cartridge):
 
 def load_rom_from_file(path):
   with open(path, "rb") as f:
-    # 2/3: Python 2's "bytes" type is useless, so we have to use a bytearray to get the
-    # behavior we want.
     romstring = f.read()
 
   return Cartridge(romstring)

--- a/gb/cpu.py
+++ b/gb/cpu.py
@@ -1,4 +1,4 @@
-class cpu:
+class Cpu(object):
   def __init__(self, mmu):
     self.mmu = mmu
     self.pc = 0

--- a/gb/mem.py
+++ b/gb/mem.py
@@ -1,10 +1,10 @@
-class DummyMem:
+class DummyMem(object):
   def __getitem__(self,addr):
     return 0
   def __setitem(self,addr,value):
     pass
 
-class ROM(DummyMem):
+class Rom(DummyMem):
   def __init__(self, data):
     self.data = bytearray(data)
 

--- a/gb/mmu.py
+++ b/gb/mmu.py
@@ -1,7 +1,7 @@
 from gb.mem import *
 from gb.cartridge import *
 
-class Mmu:
+class Mmu(object):
   def __init__(self, bios, vram, oam, io):
     self.wram = bytearray(0xE000 - 0xC000)
     self.zram = bytearray(0x10000 - 0xFF80)

--- a/gb/mmu.py
+++ b/gb/mmu.py
@@ -11,7 +11,7 @@ class Mmu(object):
     self.oam = oam
     self.io = io
 
-    self.cartridge = DummyCartridge()
+    self.cartridge = Cartridge()
 
     self.in_bios = True
 
@@ -80,4 +80,4 @@ class Mmu(object):
     self.cartridge = cartridge
 
   def unload_cartridge(self, cartridge):
-    self.cartridge = DummyCartridge()
+    self.cartridge = Cartridge()

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,8 @@ setup(
   long_description=read("README.md"),
   packages=["gb"],
   test_suite="test",
+  install_requires=[
+    # Python 2/3 compatibility:
+    "six",
+  ],
 )

--- a/test/test_cartridge.py
+++ b/test/test_cartridge.py
@@ -1,0 +1,48 @@
+import six
+import unittest
+
+from gb.cartridge import *
+
+class TestCartridge(unittest.TestCase):
+
+    def setUp(self):
+        @six.add_metaclass(CartridgeMeta)
+        class base(object):
+            pass
+        self.base = base
+
+        self.test_romstring = b"\x00" * 0x147 + b"\x01"
+
+    def testCartridgeSelect(self):
+        dummy_cartridge = Cartridge()
+        self.assertIs(type(dummy_cartridge), DummyCartridge)
+
+        mcb1_cartridge = Cartridge(self.test_romstring)
+        self.assertIs(type(mcb1_cartridge), Mbc1Cartridge)
+
+    def testConstructIllegal(self):
+        with self.assertRaises(ValueError):
+            Cartridge(b"not long enough")
+        with self.assertRaises(ValueError):
+            Cartridge(b"\x00" * 0x147 + b"\xFF")
+        with self.assertRaises(ValueError):
+            DummyCartridge()
+
+    def testIllegalRegistration(self):
+        class derived1(self.base):
+            ids = [0x0]
+
+        with self.assertRaises(RegistrationError):
+            class derived2(self.base):
+                ids = [0x0]
+
+    def testRegistration(self):
+        class derived1(self.base):
+            ids = [0x0]
+        self.assertIs(self.base._cartridge_registry[0x0], derived1)
+
+        class derived2(self.base):
+            ids = [0x1, 0x2]
+
+        self.assertIs(self.base._cartridge_registry[0x1], derived2)
+        self.assertIs(self.base._cartridge_registry[0x1], derived2)

--- a/test/test_cartridge.py
+++ b/test/test_cartridge.py
@@ -11,7 +11,7 @@ class TestCartridge(unittest.TestCase):
             pass
         self.base = base
 
-        self.test_romstring = b"\x00" * 0x147 + b"\x01"
+        self.test_romstring = b"\x00" * ROM_TYPE_BYTE + b"\x01"
 
     def testCartridgeSelect(self):
         dummy_cartridge = Cartridge()
@@ -24,7 +24,7 @@ class TestCartridge(unittest.TestCase):
         with self.assertRaises(ValueError):
             Cartridge(b"not long enough")
         with self.assertRaises(ValueError):
-            Cartridge(b"\x00" * 0x147 + b"\xFF")
+            Cartridge(b"\x00" * ROM_TYPE_BYTE + b"\xFF")
         with self.assertRaises(ValueError):
             DummyCartridge()
 

--- a/test/test_cartridge.py
+++ b/test/test_cartridge.py
@@ -5,44 +5,44 @@ from gb.cartridge import *
 
 class TestCartridge(unittest.TestCase):
 
-    def setUp(self):
-        @six.add_metaclass(CartridgeMeta)
-        class base(object):
-            pass
-        self.base = base
+  def setUp(self):
+    @six.add_metaclass(CartridgeMeta)
+    class base(object):
+      pass
+    self.base = base
 
-        self.test_romstring = b"\x00" * ROM_TYPE_BYTE + b"\x01"
+    self.test_romstring = b"\x00" * ROM_TYPE_BYTE + b"\x01"
 
-    def testCartridgeSelect(self):
-        dummy_cartridge = Cartridge()
-        self.assertIs(type(dummy_cartridge), DummyCartridge)
+  def testCartridgeSelect(self):
+    dummy_cartridge = Cartridge()
+    self.assertIs(type(dummy_cartridge), DummyCartridge)
 
-        mcb1_cartridge = Cartridge(self.test_romstring)
-        self.assertIs(type(mcb1_cartridge), Mbc1Cartridge)
+    mcb1_cartridge = Cartridge(self.test_romstring)
+    self.assertIs(type(mcb1_cartridge), Mbc1Cartridge)
 
-    def testConstructIllegal(self):
-        with self.assertRaises(ValueError):
-            Cartridge(b"not long enough")
-        with self.assertRaises(ValueError):
-            Cartridge(b"\x00" * ROM_TYPE_BYTE + b"\xFF")
-        with self.assertRaises(ValueError):
-            DummyCartridge()
+  def testConstructIllegal(self):
+    with self.assertRaises(ValueError):
+      Cartridge(b"not long enough")
+    with self.assertRaises(ValueError):
+      Cartridge(b"\x00" * ROM_TYPE_BYTE + b"\xFF")
+    with self.assertRaises(ValueError):
+      DummyCartridge()
 
-    def testIllegalRegistration(self):
-        class derived1(self.base):
-            ids = [0x0]
+  def testIllegalRegistration(self):
+    class derived1(self.base):
+      ids = [0x0]
 
-        with self.assertRaises(RegistrationError):
-            class derived2(self.base):
-                ids = [0x0]
+    with self.assertRaises(RegistrationError):
+      class derived2(self.base):
+        ids = [0x0]
 
-    def testRegistration(self):
-        class derived1(self.base):
-            ids = [0x0]
-        self.assertIs(self.base._cartridge_registry[0x0], derived1)
+  def testRegistration(self):
+    class derived1(self.base):
+      ids = [0x0]
+    self.assertIs(self.base._cartridge_registry[0x0], derived1)
 
-        class derived2(self.base):
-            ids = [0x1, 0x2]
+    class derived2(self.base):
+      ids = [0x1, 0x2]
 
-        self.assertIs(self.base._cartridge_registry[0x1], derived2)
-        self.assertIs(self.base._cartridge_registry[0x1], derived2)
+    self.assertIs(self.base._cartridge_registry[0x1], derived2)
+    self.assertIs(self.base._cartridge_registry[0x1], derived2)

--- a/test/test_mmu.py
+++ b/test/test_mmu.py
@@ -1,5 +1,6 @@
 import unittest
 
+from gb.mem import *
 from gb.mmu import *
 
 class TestMmuMethods(unittest.TestCase):


### PR DESCRIPTION
This set of changes does two things.

First, it changes all classes to explicitly inherit from `object`. In Python 3, this does nothing, but in Python 2, this changes these classes from old-style classes to new-style classes. This changes some edge cases in python's data model such as removing `__getslice__` in favor of calling `__getitem__` with a `slice` object as the index parameter. This improves 2/3 compatibility and just generally makes things better.

The other change is to the cartridge module. This changes the selection of Cartridge classes to be done through inheritance and metaclass programming instead of creating a function that maually selects the appropriate class of cartridge.

Before this change, cartridges were selected by this function:

``` python
def load_rom_from_file(path):
  with open(path, "rb") as f:
    romstring = f.read()

  cart_type = romstring[0x147]

  if cart_type in MBC1Cartridge.ids:
    return MBC1Cartridge(romstring)
  else:
    raise ValueError("Cartridge of unsupported type.")
```

Note how the function manually checks the `ids` in `MBC1Cartridge`. This means that as the rest of the cartridge types are developed, each would have to be added to this function manually.

This function is changed to this:

``` python
def load_rom_from_file(path):
  with open(path, "rb") as f:
    romstring = f.read()

  return Cartridge(romstring)
```

Now all the work of determining the correct type of cartridge to construct has been moved to within the Cartridge class. `load_rom_from_file` doesn't need to know anything about the contents of the rom.

The way this works is in to parts. First is the metaclass `CartridgeMeta`. This metaclass implements a registry so that any object hierarchy which uses it as its metaclass will automatically have a class-level variable called `_cartridge_registry` added to it, and any subclasses of that base class which define the class-level variable `ids` will automatically be added to the registry. The metaclass also prevents accidents where the programmer specifies the same cartridge type ID twice, by raising an error if a class attempts to register an id that has already been registered.

Then the `__new__` method of `Cartridge` is defined to check in its internal registry, provided by the metaclass, whenever an instance of `Cartridge` is requested. Instead of returning a base `Cartridge` object, the subclass which matches the id in the romstring is returned, and if none match, an error is raised. If no romstring is passed, a `DummyCartridge` is returned.

Additionally, some unit tests are provided for the `Cartridge` metaclass/slection system.

This has been tested in both Python 2 and 3.

Note that this request creates a dependency on the "six" module from pypi. This module proves a number of helpers for Python 2/3 compatibility.
